### PR TITLE
refactor device field mapping for panel

### DIFF
--- a/src/components/Topology3D.tsx
+++ b/src/components/Topology3D.tsx
@@ -12,7 +12,7 @@ function useLayout(devices: Device[]) {
     const nodes = devices.map((d, i) => {
       const a = (i / n) * Math.PI * 2;
       return {
-        id: Number(d.id), // numeric id from backend
+        id: d.id,
         name: d.name,
         status: d.status,
         pos: new THREE.Vector3(
@@ -36,8 +36,8 @@ function useLayout(devices: Device[]) {
 }
 
 type NodeBallProps = {
-  node: { id: number; name: string; status: Device["status"]; pos: THREE.Vector3 };
-  onPick: (id: number) => void;
+  node: { id: Device["id"]; name: string; status: Device["status"]; pos: THREE.Vector3 };
+  onPick: (id: Device["id"]) => void;
 };
 
 function NodeBall({ node, onPick }: NodeBallProps) {
@@ -93,7 +93,7 @@ export default function Topology3D({
   onPick,
 }: {
   devices: Device[];
-  onPick: (id: number) => void;
+  onPick: (id: Device["id"]) => void;
 }) {
   const { nodes, links } = useLayout(devices);
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,7 @@
 export type DeviceStatus = "online" | "degraded" | "offline";
 
 export type Device = {
-  id: number;
+  id: string;
   name: string;
   status: DeviceStatus;
   cpu: number;          // latest %
@@ -9,7 +9,7 @@ export type Device = {
 };
 
 export type DeviceDetails = {
-  id: number;
+  id: string;
   name: string;
   status: DeviceStatus;
   metrics: {


### PR DESCRIPTION
## Summary
- ensure DevicePanel consistently maps backend fields and loads device logs
- allow Topology3D node selection to open device details
- treat device identifiers as strings across types

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2f929bde48326bd4c9a6636640861